### PR TITLE
fix: iteration when counts object is empty

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -16,14 +16,7 @@ impl<'inner> Iterator for MultiSiteCountsIter<'inner> {
     type Item = SiteCounts<'inner>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.next_site_ind.0 > self.next_site_ind.1 {
-            return None;
-        }
-
-        let ret = self
-            .inner
-            .counts_at(self.next_site_ind.0)
-            .expect("forward iterator index out of range");
+        let ret = self.inner.counts_at(self.next_site_ind.0)?;
 
         self.next_site_ind.0 += 1;
         Some(ret)
@@ -32,16 +25,21 @@ impl<'inner> Iterator for MultiSiteCountsIter<'inner> {
 
 impl DoubleEndedIterator for MultiSiteCountsIter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.next_site_ind.1 < self.next_site_ind.0 {
-            return None;
-        }
-
-        let ret = self
-            .inner
-            .counts_at(self.next_site_ind.1)
-            .expect("reverse iterator index out of range");
+        let ret = self.inner.counts_at(self.next_site_ind.1)?;
 
         self.next_site_ind.1 -= 1;
         Some(ret)
     }
+}
+
+#[test]
+fn test_iteration_over_empty() {
+    let counts = crate::MultiSiteCounts::default();
+    assert_eq!(counts.iter().count(), 0)
+}
+
+#[test]
+fn test_reverse_iteration_over_empty() {
+    let counts = crate::MultiSiteCounts::default();
+    assert_eq!(counts.iter().rev().count(), 0)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,14 @@ impl MultiSiteCounts {
     pub fn iter(&self) -> MultiSiteCountsIter {
         MultiSiteCountsIter {
             inner: self,
-            next_site_ind: (0, self.count_starts.len() - 1),
+            next_site_ind: (
+                0,
+                if !self.count_starts.is_empty() {
+                    self.count_starts.len() - 1
+                } else {
+                    0
+                },
+            ),
         }
     }
 


### PR DESCRIPTION
The iterator types are not robust.
The edge case of empty data fails.

#2 is blocked because of this issue.
