### PR TITLE
new lifetime elision lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ impl MultiSiteCounts {
         self.total_alleles.is_empty()
     }
 
-    pub fn iter(&self) -> MultiSiteCountsIter {
+    pub fn iter(&self) -> MultiSiteCountsIter<'_> {
         MultiSiteCountsIter {
             inner: self,
             next_site_ind: (
@@ -169,7 +169,7 @@ impl MultiSiteCounts {
     /// Get the allele counts at a specific site index.
     ///
     /// Returns [`None`] if the site index is invalid.
-    pub fn get(&self, site: usize) -> Option<SiteCounts> {
+    pub fn get(&self, site: usize) -> Option<SiteCounts<'_>> {
         Some(SiteCounts {
             counts: self.counts_slice_at(site)?,
             total_alleles: self.total_alleles[site],

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -227,7 +227,7 @@ impl F_ST {
     /// Construct an [`F_STView`] from this struct with the provided `selected_populations`.
     /// It is assumed these are valid indices into the populations already provided to `self`, panicking otherwise.
     /// The terms necessary to compute F-statistics are recomputed immediately.
-    pub fn only_populations(&self, selected_populations: HashSet<usize>) -> F_STView {
+    pub fn only_populations(&self, selected_populations: HashSet<usize>) -> F_STView<'_> {
         #[allow(non_snake_case)]
         let mut pi_S = (0., 0.);
         #[allow(non_snake_case)]


### PR DESCRIPTION
Introduced in 1.89.0:
https://doc.rust-lang.org/stable/rustc/lints/listing/warn-by-default.html#mismatched-lifetime-syntaxes
