### PR TITLE
feat!(counts): inputting new data is fallible on correctness

### DIFF
--- a/src/from_tree_sequence.rs
+++ b/src/from_tree_sequence.rs
@@ -179,7 +179,11 @@ pub fn try_from_tree_sequence(
                 .count()
                 > 1
             {
-                counts.add_site_from_counts(&allele_counts, num_sampled_genomes);
+                // this won't panic because our counts are ultimately derived from a collection of
+                // alleles, which always obeys the required properties
+                counts
+                    .add_site_from_counts(&allele_counts, num_sampled_genomes)
+                    .unwrap();
             }
             current_site_index += 1;
         }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -89,17 +89,17 @@ fn test_reverse_iteration_over_empty() {
 #[test]
 fn test_count() {
     let mut counts = MultiSiteCounts::default();
-    counts.add_site_from_counts([1, 2, 3], 6);
+    counts.add_site_from_counts([1, 2, 3], 6).unwrap();
     assert_eq!(counts.iter().count(), 1);
 }
 
 #[cfg(test)]
 fn make_nonempty_counts() -> MultiSiteCounts {
     let mut counts = MultiSiteCounts::default();
-    counts.add_site_from_counts([1, 2, 3], 6);
-    counts.add_site_from_counts([1, 1, 1], 3);
-    counts.add_site_from_counts([1, 5, 1], 7);
-    counts.add_site_from_counts([1, 6, 2], 9);
+    counts.add_site_from_counts([1, 2, 3], 6).unwrap();
+    counts.add_site_from_counts([1, 1, 1], 3).unwrap();
+    counts.add_site_from_counts([1, 5, 1], 7).unwrap();
+    counts.add_site_from_counts([1, 6, 2], 9).unwrap();
 
     counts
 }
@@ -147,7 +147,7 @@ fn test_exhaust_back() {
 #[test]
 fn test_single_site_getters() {
     let mut counts = MultiSiteCounts::default();
-    counts.add_site_from_counts([9, 8, 7], 35);
+    counts.add_site_from_counts([9, 8, 7], 35).unwrap();
     let site = counts.get(0).unwrap();
     assert_eq!(site.counts(), &[9, 8, 7]);
     assert_eq!(site.total_alleles(), 35);

--- a/src/test.rs
+++ b/src/test.rs
@@ -335,6 +335,22 @@ chr0	1	.	G	A	.	.	.	GT	/0	/1	/1	/0	/1	/1	/0	/0	/.	/.	/0	/0	/1	/1	/1	/1	/0	/."#
     }
 
     #[test]
+    #[should_panic]
+    fn bad_site_negative_count() {
+        let mut counts = MultiSiteCounts::default();
+
+        counts.add_site_from_counts([-1, -2, -3], 100).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn bad_site_deficient_total() {
+        let mut counts = MultiSiteCounts::default();
+
+        counts.add_site_from_counts([1, 2, 3], 1).unwrap();
+    }
+
+    #[test]
     fn global_pi() {
         let mut rng = rng();
         let sites = vec![


### PR DESCRIPTION
We make the function `MutliSiteCounts::add_site_from_counts` which accepts user data newly fallible on the following two conditions:

- Any count of alleles is non-negative.
- Any sum of missing and present alleles is not less than the sum of counts of present alleles.
This is done by checking, then delegating to unchecked variants of these functions.
These may be `pub` at some point in the future.

The original plan was to only add `debug_assert!`s in #43.