### PR TITLE
feat: multi population counts

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,12 +1,16 @@
 #[cfg(feature = "noodles")]
 pub mod vcf {
+    use crate::counts::MultiPopulationCounts;
     use crate::{AlleleID, PopgenResult};
+    pub use noodles::vcf as noodles_vcf;
     use noodles::vcf::variant::record::samples::keys::key;
     use noodles::vcf::variant::record::samples::series::Value;
     use noodles::vcf::variant::record::samples::Sample;
+    use noodles::vcf::variant::record::AlternateBases;
     use noodles::vcf::{Header, Record};
-
-    pub use noodles::vcf as noodles_vcf;
+    use std::borrow::Cow;
+    use std::collections::HashMap;
+    use std::ops::ControlFlow;
 
     pub fn record_to_genotypes_adapter(
         header: &Header,
@@ -60,5 +64,143 @@ pub mod vcf {
             };
         }
         Ok(genotypes)
+    }
+
+    /// `ploidy`, if not passed, will be inferred from the first record seen.
+    pub struct VCFToPopulationsAdapter<'h> {
+        header: &'h Header,
+        ploidy: Option<usize>,
+        population_name_to_idx: HashMap<String, usize>,
+        sample_to_population: Vec<usize>,
+        populations: MultiPopulationCounts,
+        // buffers for add_record
+        buf_counts: Vec<i64>,
+        buf_num_samples: Box<[usize]>,
+    }
+
+    pub trait WhichPopulation<E> {
+        fn which_population<'s>(&'s mut self, sample_name: &'_ str) -> Result<Cow<'s, str>, E>;
+    }
+
+    impl<T, E> WhichPopulation<E> for &mut T
+    where
+        T: WhichPopulation<E>,
+    {
+        fn which_population<'s>(&'s mut self, sample_name: &'_ str) -> Result<Cow<'s, str>, E> {
+            (*self).which_population(sample_name)
+        }
+    }
+
+    impl<'h> VCFToPopulationsAdapter<'h> {
+        pub fn new<W, E>(
+            header: &'h Header,
+            ploidy: Option<usize>,
+            mut mapper: W,
+        ) -> Result<Self, E>
+        where
+            W: WhichPopulation<E>,
+        {
+            let num_samples = header.sample_names().len();
+            let mut sample_to_population = Vec::with_capacity(num_samples);
+            let mut population_name_to_idx = HashMap::new();
+
+            if let ControlFlow::Break(err) =
+                header.sample_names().iter().try_for_each(|sample_name| {
+                    sample_to_population.push({
+                        let pop_name = match mapper.which_population(sample_name) {
+                            Ok(name) => name,
+                            Err(e) => return ControlFlow::Break(e),
+                        };
+
+                        if !population_name_to_idx.contains_key(&*pop_name) {
+                            let population_id = population_name_to_idx.len();
+                            population_name_to_idx.insert(pop_name.into_owned(), population_id);
+                            population_id
+                        } else {
+                            *population_name_to_idx.get(&*pop_name).unwrap()
+                        }
+                    });
+
+                    ControlFlow::Continue(())
+                })
+            {
+                return Err(err);
+            };
+
+            let num_populations = population_name_to_idx.len();
+
+            Ok(Self {
+                header,
+                ploidy,
+                sample_to_population,
+                population_name_to_idx,
+                populations: MultiPopulationCounts::of_empty_populations(num_populations),
+                // we'll resize if we ever get a record with more variants
+                buf_counts: vec![0; num_populations * 2],
+                buf_num_samples: vec![0; num_populations].into_boxed_slice(),
+            })
+        }
+
+        pub fn add_record(&mut self, record: &Record) -> PopgenResult<()> {
+            let num_populations = self.populations.num_populations();
+
+            // let's assume that every stated allele is used
+            let num_variants = 1 + record.alternate_bases().iter().count();
+
+            let new_buf_counts_len = num_populations * num_variants;
+            if new_buf_counts_len > self.buf_counts.len() {
+                self.buf_counts.fill(0);
+                self.buf_counts.resize(new_buf_counts_len, 0);
+            } else {
+                self.buf_counts.truncate(new_buf_counts_len);
+                self.buf_counts.fill(0);
+            }
+
+            self.buf_num_samples.fill(0);
+
+            for (sample_i, sample) in record.samples().iter().enumerate() {
+                let population_id = self.sample_to_population[sample_i];
+                match sample
+                    // get the GT field
+                    .get(self.header, key::GENOTYPE)
+                    .transpose()?
+                    .flatten()
+                {
+                    // return nothing if field or value missing
+                    None => {
+                        let Some(ref ploidy) = self.ploidy else {
+                            todo!("can't infer ploidy")
+                        };
+
+                        self.buf_num_samples[population_id] += *ploidy;
+                    }
+                    Some(Value::Genotype(genotype)) => {
+                        for entry in genotype.iter() {
+                            let (allele_id, _) = entry?;
+                            self.buf_num_samples[population_id] += 1;
+                            if let Some(allele_id) = allele_id {
+                                self.buf_counts[population_id * num_populations + allele_id] += 1;
+                            }
+                        }
+                    }
+                    Some(_) => todo!("not a gt?"),
+                };
+            }
+
+            self.populations
+                .extend_populations_from_site(|population_i| {
+                    (
+                        &self.buf_counts
+                            [population_i * num_populations..(population_i + 1) * num_populations],
+                        self.buf_num_samples[population_i],
+                    )
+                })?;
+
+            Ok(())
+        }
+
+        pub fn build(self) -> (HashMap<String, usize>, MultiPopulationCounts) {
+            (self.population_name_to_idx, self.populations)
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,10 @@ pub enum PopgenError {
     NoodlesVCF(std::io::Error),
     #[cfg(feature = "tskit")]
     Tskit(tskit::TskitError),
+    Io(std::io::Error),
     NegativeCount(Count),
     TotalAllelesDeficient,
+    MismatchedSliceLength,
 }
 
 impl std::fmt::Display for PopgenError {
@@ -47,6 +49,10 @@ impl std::fmt::Display for PopgenError {
                 f,
                 "stated total alleles is less than sum of counts of present variants"
             ),
+            PopgenError::Io(e) => write!(f, "io error: {}", e),
+            PopgenError::MismatchedSliceLength => {
+                write!(f, "slices were expected to be of the same length")
+            }
             #[cfg(feature = "tskit")]
             PopgenError::Tskit(e) => write!(f, "tskit error: {}", e),
             #[cfg(feature = "noodles")]
@@ -56,6 +62,12 @@ impl std::fmt::Display for PopgenError {
 }
 
 impl std::error::Error for PopgenError {}
+
+impl From<std::io::Error> for PopgenError {
+    fn from(e: std::io::Error) -> Self {
+        PopgenError::Io(e)
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AlleleID(usize);


### PR DESCRIPTION
We address the previous failure of `F_ST` to enforce allele ID invariance over its populations using a new `MultiPopulationCounts` which enforces this invariant during construction.

F_ST is refactored to only be constructible via this new type.

**blocked by #67**
