### PR TITLE
feat: framework for parallelizable statistic computation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
           cargo run --example from_vcf --features=noodles
           cargo run --example from_vcf_indexed --features=noodles
           cargo run --example from_tskit --features=tskit
+          cargo run --example concurrent --features=noodles
 
   fmt:
     name: rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +486,7 @@ dependencies = [
  "proptest",
  "rand",
  "rand_distr",
+ "rayon",
  "tskit",
 ]
 
@@ -580,6 +600,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ tskit = { version = ">=0.16.3", optional = true, features = ["bindings"] }
 rand = "0.9.0"
 noodles = { version = "*", features = ["vcf", "csi", "tabix", "bgzf", "core"] }
 rand_distr = "0.5.1"
+rayon = "1.11.0"
 proptest = "1.10.0"
 
 [profile.release]
@@ -28,3 +29,6 @@ required-features = ["noodles"]
 name = "from_tskit"
 required-features = ["tskit"]
 
+[[example]]
+name = "concurrent"
+required-features = ["noodles"]

--- a/examples/concurrent.rs
+++ b/examples/concurrent.rs
@@ -1,0 +1,44 @@
+//! Example of concurrent computation enabled by the `SiteComposable` trait.
+
+use noodles::vcf;
+use popgen::adapter::vcf::record_to_genotypes_adapter;
+use popgen::stats::{GlobalPi, GlobalStatistic, SiteComposable};
+use popgen::{MultiSiteCounts, PopgenError};
+use rayon::iter::ParallelBridge;
+use rayon::iter::ParallelIterator;
+use std::io::Cursor;
+
+static VCF_FILE: &str = r#"##fileformat=VCFv4.5
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr0>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	s0	s1	s2	s3	s4	s5	s6	s7	s8	s9	s10	s11	s12	s13	s14	s15	s16	s17
+chr0	1	.	A	C	.	.	.	GT	/0	/1	/1	/0	/1	/0	/1	/0	/0	/0	/0	/0	/0	/1	/0	/1	/1	/0
+chr0	1	.	G	A	.	.	.	GT	/0	/1	/1	/0	/1	/1	/0	/0	/.	/.	/0	/0	/1	/1	/1	/1	/0	/."#;
+
+fn main() {
+    let mut reader = vcf::io::Reader::new(Cursor::new(VCF_FILE.as_bytes()));
+    let header = reader.read_header().unwrap();
+
+    let mut record = vcf::Record::default();
+    let iter = std::iter::from_fn(move || match reader.read_record(&mut record).unwrap() {
+        0 => None,
+        _ => Some(record.clone()),
+    });
+
+    let out = iter
+        .par_bridge()
+        .map(|rec| record_to_genotypes_adapter(&header, &rec, 1).unwrap())
+        .try_fold(GlobalPi::default, |mut pi, alleles| {
+            let mut multi = MultiSiteCounts::default();
+            multi.add_site(alleles).unwrap();
+            pi.try_add_site(multi.get(0).unwrap())?;
+            Ok::<_, PopgenError>(pi)
+        })
+        .try_reduce(GlobalPi::default, |mut a, b| {
+            a.try_combine(&b)?;
+            Ok::<_, PopgenError>(a)
+        })
+        .unwrap();
+
+    dbg!(out);
+}

--- a/examples/from_vcf.rs
+++ b/examples/from_vcf.rs
@@ -22,7 +22,7 @@ fn main() {
         // ignore IO errors
         .map(Result::unwrap)
         // this crate maps a record to allele IDs for you
-        .map(|rec| record_to_genotypes_adapter(&header, rec, ploidy).unwrap());
+        .map(|rec| record_to_genotypes_adapter(&header, &rec, ploidy).unwrap());
 
     // this constructor is iterator-based
     let counts = MultiSiteCounts::try_from_tabular(all_alleles).unwrap();

--- a/examples/from_vcf_indexed.rs
+++ b/examples/from_vcf_indexed.rs
@@ -45,7 +45,7 @@ fn main() {
     let alleles = query
         .records()
         .map(Result::unwrap)
-        .map(|rec| record_to_genotypes_adapter(&header, rec, ploidy).unwrap());
+        .map(|rec| record_to_genotypes_adapter(&header, &rec, ploidy).unwrap());
     let counts = MultiSiteCounts::try_from_tabular(alleles).unwrap();
     counts.iter().for_each(|c| println!("{c:?}"));
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -11,7 +11,7 @@ pub mod vcf {
 
     pub fn record_to_genotypes_adapter(
         header: &Header,
-        record: Record,
+        record: &Record,
         ploidy: usize,
     ) -> PopgenResult<Vec<Option<AlleleID>>> {
         let num_samples = header.sample_names().len();

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,6 +1,6 @@
 use crate::iter::SiteCounts;
 use crate::util::UnorderedPair;
-use crate::{Count, MultiPopulationCounts, PopgenError};
+use crate::{Count, MultiPopulationCounts, MultiSiteCounts, PopgenError, PopgenResult};
 use std::cmp::max;
 use std::collections::HashMap;
 
@@ -60,6 +60,133 @@ pub trait GlobalStatistic {
     fn as_raw(&self) -> f64;
 }
 
+/// A [`GlobalStatistic`], with the following additional guarantees:
+/// - The statistic can be updated with at least one site when given a reference to another `Self` to which site(s) have already been added.
+/// - This composition remains correct under reordering (commutation and association).
+///
+/// It is also possible to implement this trait if a sufficient *portion* of computation can be done
+/// under the above conditions.
+/// Such types can use [`GlobalStatistic::as_raw`] to perform inexpensive finalizing computations
+/// if needed.
+/// For an example of this use case, see [`TajimaD`].
+///
+/// # Errors
+///
+/// - The statistic is not required to be in a valid state after [`try_combine`](Self::try_combine) fails.
+///
+/// # Example
+/// ```
+/// # use popgen::iter::SiteCounts;
+/// # use popgen::PopgenResult;
+/// # use popgen::stats::{GlobalStatistic, SiteComposable};
+/// #
+/// // a very simple statistic
+/// #[derive(Default)]  // to define the result over 0 sites
+/// struct NumSites(u64);
+///
+/// impl SiteComposable for NumSites {
+///     fn try_combine(&mut self, other: &Self) -> PopgenResult<()> {
+///         self.0 += other.0;
+///         Ok(())
+///     }
+/// }
+///
+/// impl GlobalStatistic for NumSites {
+///     fn try_add_site(&mut self, site: SiteCounts) -> PopgenResult<()> {
+///         self.0 += 1;
+///         Ok(())
+///     }
+///
+///     fn as_raw(&self) -> f64 {
+///         self.0 as f64
+///     }
+/// }
+/// ```
+pub trait SiteComposable: GlobalStatistic {
+    fn try_combine(&mut self, other: &Self) -> crate::PopgenResult<()>;
+}
+
+pub fn windowed<Stat, GetWindow, E>(
+    window_size: i64,
+    stride: i64,
+    start_pos: i64,
+    end_pos: i64,
+    mut get_window: GetWindow,
+) -> PopgenResult<Result<Vec<Stat>, E>>
+where
+    Stat: SiteComposable + Default + Clone,
+    GetWindow: FnMut(i64, i64) -> Result<MultiSiteCounts, E>,
+{
+    let use_add_remove = window_size > stride;
+    let mut intersection = None::<Stat>;
+
+    let mut ret = Vec::with_capacity(((end_pos - start_pos + 1) / stride + 1) as usize);
+
+    let mut window_start = start_pos;
+    // TODO: parallelize this under some condition
+
+    while window_start < end_pos {
+        let mut accum = Stat::default();
+        if !use_add_remove {
+            let counts = match get_window(window_start, (window_start + window_size).min(end_pos)) {
+                Ok(window) => window,
+                Err(e) => return Ok(Err(e)),
+            };
+            for site in counts.iter() {
+                accum.try_add_site(site)?;
+            }
+        } else {
+            let new_intersection = match get_window(
+                window_start + window_size - stride,
+                window_start + window_size,
+            ) {
+                Ok(window) => window,
+                Err(e) => return Ok(Err(e)),
+            }
+            .iter()
+            .try_fold(Stat::default(), |mut stat, site| {
+                stat.try_add_site(site)?;
+                PopgenResult::Ok(stat)
+            })?;
+
+            if let Some(ref intersection) = intersection {
+                accum.try_combine(intersection)?;
+
+                let new_part = match get_window(window_start + stride, window_start + window_size) {
+                    Ok(window) => window,
+                    Err(e) => return Ok(Err(e)),
+                };
+                new_part
+                    .iter()
+                    .try_fold(Stat::default(), |mut stat, site| {
+                        stat.try_add_site(site)?;
+                        PopgenResult::Ok(stat)
+                    })?;
+            } else {
+                let first_part = match get_window(window_start, window_start + window_size - stride)
+                {
+                    Ok(window) => window,
+                    Err(e) => return Ok(Err(e)),
+                };
+                first_part
+                    .iter()
+                    .try_fold(Stat::default(), |mut stat, site| {
+                        stat.try_add_site(site)?;
+                        PopgenResult::Ok(stat)
+                    })?;
+
+                accum.try_combine(&new_intersection)?;
+                intersection = Some(new_intersection);
+            }
+
+            ret.push(accum);
+            window_start += stride;
+        }
+    }
+
+    Ok(Ok(ret))
+}
+
 /// The expected number of differences between two samples over all sites, the "expected pairwise diversity".
 ///
 /// This is the sum of [`Pi`] over all sites.
@@ -89,6 +216,16 @@ impl GlobalStatistic for GlobalPi {
 
     fn as_raw(&self) -> f64 {
         self.0
+    }
+}
+
+impl SiteComposable for GlobalPi {
+    fn try_combine(&mut self, other: &Self) -> PopgenResult<()> {
+        if self.0.is_nan() || other.0.is_nan() {
+            return Err(PopgenError::CalculationError);
+        }
+        self.0 += other.as_raw();
+        Ok(())
     }
 }
 
@@ -123,11 +260,19 @@ impl GlobalStatistic for WattersonTheta {
             let harmonic = (1..total_samples).map(|i| 1f64 / i as f64).sum::<f64>();
             self.0 += (num_variants - 1) as f64 / harmonic;
         }
+
         Ok(())
     }
 
     fn as_raw(&self) -> f64 {
         self.0
+    }
+}
+
+impl SiteComposable for WattersonTheta {
+    fn try_combine(&mut self, other: &Self) -> PopgenResult<()> {
+        self.0 += other.0;
+        Ok(())
     }
 }
 
@@ -193,6 +338,20 @@ impl GlobalStatistic for TajimaD {
     }
 }
 
+impl SiteComposable for TajimaD
+where
+    GlobalPi: SiteComposable,
+    WattersonTheta: SiteComposable,
+{
+    fn try_combine(&mut self, other: &Self) -> PopgenResult<()> {
+        self.k_hat.try_combine(&other.k_hat)?;
+        self.theta.try_combine(&other.theta)?;
+        self.num_samples += other.num_samples;
+        self.num_sites += other.num_sites;
+        Ok(())
+    }
+}
+
 /// Fixation statistics as in [Charlesworth (1998)](https://doi.org/10.1093/oxfordjournals.molbev.a025953).
 ///
 /// Construction of this type from an arbitrary collection of [`MultiSiteCounts`] is not sound,
@@ -214,18 +373,7 @@ pub struct F_ST<'backing> {
     pi_B: (f64, f64),
 }
 
-impl<'backing> F_ST<'backing> {
-    pub(crate) fn new_viewing(populations: &'backing MultiPopulationCounts) -> Self {
-        Self {
-            backing: populations,
-            populations: vec![],
-            diversity_within: vec![],
-            pi_S: (0.0, 0.0),
-            diversity_between: Default::default(),
-            pi_B: (0.0, 0.0),
-        }
-    }
-
+impl<'m> F_ST<'m> {
     /// Add a population and its weight for this statistic.
     /// It is assumed that the inputted weight(s) sum to 1.
     ///
@@ -238,7 +386,6 @@ impl<'backing> F_ST<'backing> {
     ) -> Result<(), PopgenError> {
         let pi_new_site =
             GlobalPi::try_from_iter_sites(self.backing.iter_sites_in(population_num))?.as_raw();
-
         self.diversity_within.push(pi_new_site);
 
         self.pi_S.0 += weight * weight * pi_new_site;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -374,6 +374,17 @@ pub struct F_ST<'backing> {
 }
 
 impl<'m> F_ST<'m> {
+    pub(crate) fn new_viewing(backing: &'m MultiPopulationCounts) -> Self {
+        Self {
+            backing,
+            populations: vec![],
+            diversity_within: vec![],
+            pi_S: (0.0, 0.0),
+            diversity_between: Default::default(),
+            pi_B: (0.0, 0.0),
+        }
+    }
+
     /// Add a population and its weight for this statistic.
     /// It is assumed that the inputted weight(s) sum to 1.
     ///

--- a/src/testing/concurrent.rs
+++ b/src/testing/concurrent.rs
@@ -1,0 +1,144 @@
+use crate::stats::{GlobalPi, GlobalStatistic, SiteComposable, WattersonTheta};
+use crate::PopgenError;
+use proptest::collection::vec;
+use proptest::proptest;
+use rand::distr::uniform::SampleRange;
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use rand::SeedableRng;
+
+proptest!(
+// we don't need to invoke actual parallelism, just show that the component-wise approach is correct
+#[test]
+fn pi_equivalent_concurrent(
+    seed in 0..u64::MAX,
+    ploidy in 1_usize..5,
+    num_samples in 2_usize..50,
+    missing_data_rate_raw in 0_f64..1.0 - f64::EPSILON,
+    num_sites in 1_usize..10,
+    non_normalized_freqs in vec(vec(f64::EPSILON..1_f64, 1..10), 10),
+) {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let sites = super::testdata::make_random_sites(
+        &mut rng,
+        ploidy,
+        num_samples,
+        missing_data_rate_raw,
+        num_sites,
+        non_normalized_freqs,
+    );
+
+    let counts = crate::testing::testdata::single_pop_counts(&mut sites.iter());
+    let pi = counts.iter().try_fold(GlobalPi::default(), |mut pi, s| {
+        pi.try_add_site(s)?;
+        Ok::<_, PopgenError>(pi)
+    });
+
+    let mut components = counts.iter().map(|s| {
+        let mut pi = GlobalPi::default();
+        pi.try_add_site(s)?;
+        Ok::<_, PopgenError>(pi)
+    }).collect::<Vec<_>>();
+
+    // let's combine the components out of order and with random associativity
+    // this test is to make sure that this is equivalent to the serial case
+    components.shuffle(&mut rng);
+    while components.len() > 1 {
+        let pick1 = components.remove((..components.len()).sample_single(&mut rng).unwrap());
+        let pick2 = components.remove((..components.len()).sample_single(&mut rng).unwrap());
+        match (pick1, pick2) {
+            (Err(one), Ok(_)) | (Ok(_), Err(one)) | (Err(one), Err(_)) => {
+                components.push(Err(one));
+            },
+            (Ok(mut one), Ok(two)) => {
+                components.push(one.try_combine(&two).map(|_| one));
+            },
+        }
+    }
+
+    let parallel = if !components.is_empty() {
+        components.remove(0)
+    } else {
+        Ok(GlobalPi::default())
+    };
+
+    match pi {
+        Err(e) => {
+            assert_eq!(std::mem::discriminant(&e), std::mem::discriminant(&parallel.err().unwrap()));
+        },
+        Ok(pi) => {
+            let pi_raw = pi.as_raw();
+            let parallel_raw = parallel.unwrap().as_raw();
+            assert!((pi_raw - parallel_raw).abs() < 0.00001)
+        },
+    }
+}
+);
+
+proptest!(
+// we don't need to invoke actual parallelism, just show that the component-wise approach is correct
+#[test]
+fn watterson_theta_equivalent_concurrent(
+    seed in 0..u64::MAX,
+    ploidy in 1_usize..5,
+    num_samples in 2_usize..50,
+    missing_data_rate_raw in 0_f64..1.0 - f64::EPSILON,
+    num_sites in 1_usize..10,
+    non_normalized_freqs in vec(vec(f64::EPSILON..1_f64, 1..10), 10),
+) {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let sites = super::testdata::make_random_sites(
+        &mut rng,
+        ploidy,
+        num_samples,
+        missing_data_rate_raw,
+        num_sites,
+        non_normalized_freqs,
+    );
+
+    let counts = crate::testing::testdata::single_pop_counts(&mut sites.iter());
+    let theta = counts.iter().try_fold(WattersonTheta::default(), |mut theta, s| {
+        theta.try_add_site(s)?;
+        Ok::<_, PopgenError>(theta)
+    });
+
+    let mut components = counts.iter().map(|s| {
+        let mut theta = WattersonTheta::default();
+        theta.try_add_site(s)?;
+        Ok::<_, PopgenError>(theta)
+    }).collect::<Vec<_>>();
+
+    // let's combine the components out of order and with random associativity
+    // this test is to make sure that this is equivalent to the serial case
+    components.shuffle(&mut rng);
+    while components.len() > 1 {
+        let pick1 = components.remove((..components.len()).sample_single(&mut rng).unwrap());
+        let pick2 = components.remove((..components.len()).sample_single(&mut rng).unwrap());
+        match (pick1, pick2) {
+            (Err(one), Ok(_)) | (Ok(_), Err(one)) | (Err(one), Err(_)) => {
+                components.push(Err(one));
+            },
+            (Ok(mut one), Ok(two)) => {
+                components.push(one.try_combine(&two).map(|_| one));
+            },
+        }
+    }
+
+    let parallel = if !components.is_empty() {
+        components.remove(0)
+    } else {
+        Ok(WattersonTheta::default())
+    };
+
+    match theta {
+        Err(e) => {
+            assert_eq!(std::mem::discriminant(&e), std::mem::discriminant(&parallel.err().unwrap()));
+        },
+        Ok(pi) => {
+            let theta_raw = pi.as_raw();
+            let parallel_raw = parallel.unwrap().as_raw();
+            assert!((theta_raw - parallel_raw).abs() < 0.00001)
+        },
+    }
+}
+);

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -16,5 +16,6 @@ mod wattersons_theta;
 // tests of OTHER THINGS, like
 // input formats, follow
 
+mod concurrent;
 #[cfg(feature = "noodles")]
 mod noodles_vcf;

--- a/src/testing/noodles_vcf.rs
+++ b/src/testing/noodles_vcf.rs
@@ -147,7 +147,7 @@ fn counts_from_vcf(vcf_buf: &str, ploidy: usize) -> (Vec<Vec<Option<AlleleID>>>,
     let all_alleles = reader
         .records()
         .map(Result::unwrap)
-        .map(|rec| record_to_genotypes_adapter(&header, rec, ploidy))
+        .map(|rec| record_to_genotypes_adapter(&header, &rec, ploidy))
         .collect::<PopgenResult<Vec<_>>>()
         .unwrap();
     let counts = MultiSiteCounts::try_from_tabular(all_alleles.iter().cloned()).unwrap();

--- a/src/testing/pi.rs
+++ b/src/testing/pi.rs
@@ -24,30 +24,17 @@ fn pi_from_random_data(
     use rand::prelude::*;
 
     let mut rng = StdRng::seed_from_u64(seed);
-    let mut sites = vec![];
-    for nnf in non_normalized_freqs.iter().take(num_sites) {
-        let sum = nnf.iter().sum::<f64>();
-        let freqs = nnf.iter().map(|fi| fi / sum).collect::<Vec<_>>();
-        let missing_data_rate = if missing_data_rate_raw > 0.0 {
-            Some(crate::testing::testdata::RandomSiteOptions {
-                missing_data_rate: Some(missing_data_rate_raw),
-            })
-        } else {
-            None
-        };
-        let site = crate::testing::testdata::random_site_rng(
-            num_samples,
-            ploidy,
-            &freqs,
-            missing_data_rate,
-            &mut rng,
-        );
-        if !site.iter().flat_map(|i| i.iter()).all(|i| i.is_none()) {
-            sites.push(site);
-        }
-    }
+    let sites = super::testdata::make_random_sites(
+        &mut rng,
+        ploidy,
+        num_samples,
+        missing_data_rate_raw,
+        num_sites,
+        non_normalized_freqs,
+    );
     // convert to our normal format
     let counts = crate::testing::testdata::single_pop_counts(&mut sites.iter());
+
     // get the calcs
     let pi_from_counts = GlobalPi::try_from_iter_sites(counts.iter());
     let pi_naive = crate::testing::naivecalculations::pi(sites.iter());

--- a/src/testing/testdata.rs
+++ b/src/testing/testdata.rs
@@ -164,6 +164,34 @@ pub fn single_pop_counts<'s>(sites: &'s mut dyn Iterator<Item = &'s Site>) -> Mu
     mcounts
 }
 
+pub fn make_random_sites(
+    rng: &mut StdRng,
+    ploidy: usize,
+    num_samples: usize,
+    missing_data_rate_raw: f64,
+    num_sites: usize,
+    non_normalized_freqs: Vec<Vec<f64>>,
+) -> Vec<Site> {
+    let mut sites = vec![];
+    for nnf in non_normalized_freqs.iter().take(num_sites) {
+        let sum = nnf.iter().sum::<f64>();
+        let freqs = nnf.iter().map(|fi| fi / sum).collect::<Vec<_>>();
+        let missing_data_rate = if missing_data_rate_raw > 0.0 {
+            Some(RandomSiteOptions {
+                missing_data_rate: Some(missing_data_rate_raw),
+            })
+        } else {
+            None
+        };
+        let site = random_site_rng(num_samples, ploidy, &freqs, missing_data_rate, rng);
+        if !site.iter().flat_map(|i| i.iter()).all(|i| i.is_none()) {
+            sites.push(site);
+        }
+    }
+
+    sites
+}
+
 // Helper fns below
 
 // The rand crate has no multinomial function so we will make do with


### PR DESCRIPTION
- [x] Introduce the `SiteComposable` trait, guaranteeing that a `GlobalStatistic` can be computed from its parts indepedently, concurrently, and potentially out-of-order.
- [ ] ~~Use this trait to create generic code capable of parallelizing any such statistic.~~ There is an example instead.