### PR TITLE
chore: set toolchain version for development

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - run: sudo apt-get update -y
         if: matrix.os == 'ubuntu-24.04'
       - name: cargo check (powerset)
-        run: cargo hack check --feature-powerset --no-dev-deps
+        run: cargo hack check --verbose --feature-powerset --no-dev-deps
       - name: cargo check examples (powerset)
         run: cargo hack check --examples --feature-powerset
       - name: run tests (powerset)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.92.0"
+components = [ "rustfmt", "clippy" ]
+targets = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
+profile = "minimal"


### PR DESCRIPTION
This is needed so that we opt into clippy, etc., changes instead of being forced into them.
