### PR TITLE
feat!: {iter->counts}::SiteCounts::try_new

### DIFF
--- a/src/counts.rs
+++ b/src/counts.rs
@@ -259,8 +259,8 @@ impl MultiPopulationCounts {
     ///
     /// # Errors
     /// This function will fail **without rollback guarantees** if the provided slices do not match in length.
-    /// Also see [`MultiSiteCounts::add_site_from_counts`] for additional error cases.
-    /// Such an underlying error also does not provide rollback guarantees.
+    /// The sites must also be individually valid; see [`SiteCounts::try_new`].
+    /// Failure due to an invalid site does not provide rollback guarantees.
     pub fn extend_populations_from_site<Counts>(
         &mut self,
         mut get_counts: impl FnMut(usize) -> (Counts, i32),

--- a/src/counts.rs
+++ b/src/counts.rs
@@ -191,8 +191,8 @@ impl<'inner> SiteCounts<'inner> {
     /// Build a new `Self`, viewing a slice of counts and total alleles provided by the user.
     ///
     /// # Errors
-    /// This site must uphold the same properties as a site originating from a counts struct like [`MultiSiteCounts`].
-    /// Thus, those invariants still hold (in particular, see [`MultiSiteCounts::add_site_from_counts`].
+    /// The constructed site must uphold the same properties as a site originating from a counts struct like [`MultiSiteCounts`].
+    /// Therefore, constraints akin to those on [`MultiSiteCounts::add_site_from_counts`] also apply here.
     pub fn try_new(counts: &'inner [Count], total_alleles: i32) -> Result<Self, PopgenError> {
         if counts.is_empty() || total_alleles == 0 {
             return Err(PopgenError::EmptySiteCounts);

--- a/src/counts.rs
+++ b/src/counts.rs
@@ -96,10 +96,8 @@ impl MultiSiteCounts {
     /// alleles in total, including missing data.
     ///
     /// # Errors
-    /// - If any element in `counts` is negative.
-    /// - If `total_alleles` is less than the sum of elements of `counts`.
-    /// - If `counts` is empty.
-    /// - If `total_alleles == 0`.
+    /// - Passed site counts must be valid.
+    ///   See [`SiteCounts::try_new`].
     ///
     /// If any error occurs, the underlying struct has not been modified.
     // NOTE: any pub function that calls this one (probably)
@@ -114,13 +112,8 @@ impl MultiSiteCounts {
             return Err(PopgenError::EmptySiteCounts);
         }
 
-        if let Some(bad) = counts.iter().find(|&c| c < &0) {
-            return Err(PopgenError::NegativeCount(*bad));
-        }
-
-        if counts.iter().sum::<Count>() as i32 > total_alleles {
-            return Err(PopgenError::TotalAllelesDeficient);
-        }
+        // check the conditions
+        let _ = SiteCounts::try_new(counts, total_alleles)?;
 
         self.add_site_from_counts_unchecked(counts, total_alleles);
         Ok(())
@@ -181,6 +174,10 @@ impl MultiSiteCounts {
     }
 }
 
+/// A borrowed collection of allele counts and the total number of alleles (to describe, by implication, number of missing alleles).
+///
+/// This type is returned when requesting views into [`MultiSiteCounts`] and [`MultiPopulationCounts`].
+/// It can also be built from user-provided data via [`Self::try_new`].
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub struct SiteCounts<'inner> {
     pub(crate) counts: &'inner [Count],
@@ -191,18 +188,24 @@ impl<'inner> SiteCounts<'inner> {
     /// Build a new `Self`, viewing a slice of counts and total alleles provided by the user.
     ///
     /// # Errors
-    /// The constructed site must uphold the same properties as a site originating from a counts struct like [`MultiSiteCounts`].
-    /// Therefore, constraints akin to those on [`MultiSiteCounts::add_site_from_counts`] also apply here.
+    /// - If any element in `counts` is negative.
+    /// - If `total_alleles` is less than the sum of elements of `counts`.
+    /// - If `counts` is empty.
+    /// - If `total_alleles == 0`.
     pub fn try_new(counts: &'inner [Count], total_alleles: i32) -> Result<Self, PopgenError> {
         if counts.is_empty() || total_alleles == 0 {
             return Err(PopgenError::EmptySiteCounts);
         }
 
-        if let Some(bad) = counts.iter().find(|&c| c < &0) {
-            return Err(PopgenError::NegativeCount(*bad));
+        let mut sum = 0;
+        for c in counts {
+            if c < &0 {
+                return Err(PopgenError::NegativeCount(*c));
+            }
+            sum += c;
         }
 
-        if counts.iter().sum::<Count>() as i32 > total_alleles {
+        if sum as i32 > total_alleles {
             return Err(PopgenError::TotalAllelesDeficient);
         }
 
@@ -283,17 +286,7 @@ impl MultiPopulationCounts {
                 Some(_) => {}
             }
 
-            if counts.is_empty() || total_alleles == 0 {
-                return Err(PopgenError::EmptySiteCounts);
-            }
-
-            if let Some(bad) = counts.iter().find(|&c| c < &0) {
-                return Err(PopgenError::NegativeCount(*bad));
-            }
-
-            if counts.iter().sum::<Count>() as i32 > total_alleles {
-                return Err(PopgenError::TotalAllelesDeficient);
-            }
+            let _ = SiteCounts::try_new(counts, total_alleles)?;
 
             self.counts.extend(counts);
             self.total_alleles.push(total_alleles);

--- a/src/counts.rs
+++ b/src/counts.rs
@@ -1,4 +1,4 @@
-use crate::iter::{MultiSiteCountsIter, SiteCounts};
+use crate::iter::MultiSiteCountsIter;
 #[cfg(feature = "tskit")]
 use crate::{from_tree_sequence, from_tskit::FromTreeSequenceOptions};
 use crate::{AlleleID, PopgenError, PopgenResult};
@@ -178,6 +178,46 @@ impl MultiSiteCounts {
             counts: self.counts_slice_at(site)?,
             total_alleles: self.total_alleles[site],
         })
+    }
+}
+
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub struct SiteCounts<'inner> {
+    pub(crate) counts: &'inner [Count],
+    pub(crate) total_alleles: i32,
+}
+
+impl<'inner> SiteCounts<'inner> {
+    /// Build a new `Self`, viewing a slice of counts and total alleles provided by the user.
+    ///
+    /// # Errors
+    /// This site must uphold the same properties as a site originating from a counts struct like [`MultiSiteCounts`].
+    /// Thus, those invariants still hold (in particular, see [`MultiSiteCounts::add_site_from_counts`].
+    pub fn try_new(counts: &'inner [Count], total_alleles: i32) -> Result<Self, PopgenError> {
+        if counts.is_empty() || total_alleles == 0 {
+            return Err(PopgenError::EmptySiteCounts);
+        }
+
+        if let Some(bad) = counts.iter().find(|&c| c < &0) {
+            return Err(PopgenError::NegativeCount(*bad));
+        }
+
+        if counts.iter().sum::<Count>() as i32 > total_alleles {
+            return Err(PopgenError::TotalAllelesDeficient);
+        }
+
+        Ok(Self {
+            counts,
+            total_alleles,
+        })
+    }
+
+    pub fn counts(&self) -> &[Count] {
+        self.counts
+    }
+
+    pub fn total_alleles(&self) -> i32 {
+        self.total_alleles
     }
 }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,25 +1,9 @@
-use crate::{Count, MultiSiteCounts};
+use crate::{MultiSiteCounts, SiteCounts};
 
 pub struct MultiSiteCountsIter<'inner> {
     pub(crate) inner: &'inner MultiSiteCounts,
     // index of next for forward iter, index of next for reverse iter
     pub(crate) next_site_ind: (usize, usize),
-}
-
-#[derive(Eq, PartialEq, Debug, Clone)]
-pub struct SiteCounts<'inner> {
-    pub(crate) counts: &'inner [Count],
-    pub(crate) total_alleles: i32,
-}
-
-impl SiteCounts<'_> {
-    pub fn counts(&self) -> &[Count] {
-        self.counts
-    }
-
-    pub fn total_alleles(&self) -> i32 {
-        self.total_alleles
-    }
 }
 
 impl<'inner> Iterator for MultiSiteCountsIter<'inner> {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,6 +1,5 @@
-use crate::iter::SiteCounts;
 use crate::util::UnorderedPair;
-use crate::{Count, MultiPopulationCounts, MultiSiteCounts, PopgenError, PopgenResult};
+use crate::{Count, MultiPopulationCounts, MultiSiteCounts, PopgenError, PopgenResult, SiteCounts};
 use std::cmp::max;
 use std::collections::HashMap;
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -75,7 +75,7 @@ pub trait GlobalStatistic {
 ///
 /// # Example
 /// ```
-/// # use popgen::iter::SiteCounts;
+/// # use popgen::counts::SiteCounts;
 /// # use popgen::PopgenResult;
 /// # use popgen::stats::{GlobalStatistic, SiteComposable};
 /// #

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -75,8 +75,7 @@ pub trait GlobalStatistic {
 ///
 /// # Example
 /// ```
-/// # use popgen::counts::SiteCounts;
-/// # use popgen::PopgenResult;
+/// # use popgen::{PopgenResult, SiteCounts};
 /// # use popgen::stats::{GlobalStatistic, SiteComposable};
 /// #
 /// // a very simple statistic

--- a/src/testing/multisitecounts.rs
+++ b/src/testing/multisitecounts.rs
@@ -1,7 +1,6 @@
-use crate::AlleleID;
+use crate::{AlleleID, SiteCounts};
 
 use crate::counts::MultiSiteCounts;
-use crate::iter::SiteCounts;
 use rand::rng;
 use rand::rngs::ThreadRng;
 use rand::seq::SliceRandom;

--- a/src/testing/test_try_from_tree_sequence.rs
+++ b/src/testing/test_try_from_tree_sequence.rs
@@ -62,7 +62,7 @@ struct SiteCountContents {
 }
 
 #[cfg(test)]
-fn validate_site_counts(counts: &crate::iter::SiteCounts, expected: SiteCountContents) {
+fn validate_site_counts(counts: &crate::counts::SiteCounts, expected: SiteCountContents) {
     let num_alleles = expected
         .derived
         .iter()


### PR DESCRIPTION
Closes #113.

Moves `SiteCounts` from `mod iter` to `mod counts`.
Originally it was defined only for iteration, but has been reused for statistics and general querying of counts structs.
So it has been moved to a more appropriate place.
