### PR TITLE
refactor(tskit): exit early when tree sequence has no variants

### DIFF
--- a/src/from_tree_sequence.rs
+++ b/src/from_tree_sequence.rs
@@ -449,6 +449,9 @@ fn try_from_tree_sequence_details<'s, S>(
 where
     S: SampleSets<'s>,
 {
+    if ts.sites().num_rows() == 0 || ts.mutations().num_rows() == 0 {
+        return Err(PopgenError::NoInputVariants);
+    }
     let _parameters = parameters.unwrap_or_default();
     let mut sample_sets = sample_sets;
     let mut left = 0.0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub enum PopgenError {
     NoodlesVCF(std::io::Error),
     #[cfg(feature = "tskit")]
     Tskit(::tskit::TskitError),
+    NoInputVariants,
     Io(std::io::Error),
     NegativeCount(Count),
     TotalAllelesDeficient,
@@ -58,6 +59,7 @@ impl std::fmt::Display for PopgenError {
             PopgenError::LibraryError(msg) => write!(f, "{msg}"),
             #[cfg(feature = "tskit")]
             PopgenError::Tskit(e) => write!(f, "tskit error: {}", e),
+            PopgenError::NoInputVariants => write!(f, "input data has no variants"),
             #[cfg(feature = "noodles")]
             PopgenError::NoodlesVCF(e) => write!(f, "couldn't handle VCF: {}", e),
         }


### PR DESCRIPTION
When a tree sequence has no input variants, the code return Err when trying to update site counts with an empty slice.
This error message is confusing and it happens relatively late after a bunch of memory allocations have occurred.

The new error variant is intentionally not feature-gated so that it can be reused for other input types.
